### PR TITLE
Feature: suitesparse-dl tool to conver matrix market to binary csr format

### DIFF
--- a/tools/suitesparse-dl/cli.go
+++ b/tools/suitesparse-dl/cli.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/genshen/cmds"
 	_ "suitesparse-dl/batch-gen"
+	_ "suitesparse-dl/conv"
 	_ "suitesparse-dl/dl"
 	_ "suitesparse-dl/fetch"
 )

--- a/tools/suitesparse-dl/conv/conv.go
+++ b/tools/suitesparse-dl/conv/conv.go
@@ -1,0 +1,96 @@
+package conv
+
+import (
+	"encoding/binary"
+	"errors"
+	"flag"
+	"github.com/genshen/cmds"
+	"os"
+)
+
+var convCommand = &cmds.Command{
+	Name:        "conv",
+	Summary:     "conv matrix market format to csr binary format",
+	Description: "conv matrix market format to csr binary format",
+	CustomFlags: false,
+	HasOptions:  true,
+}
+
+func init() {
+	c := Conv{}
+	convCommand.Runner = &c
+	fs := flag.NewFlagSet("conv", flag.ContinueOnError)
+	convCommand.FlagSet = fs
+	convCommand.FlagSet.StringVar(&(c.input), "mm", "", `matrix market path.`)
+	convCommand.FlagSet.StringVar(&(c.output), "o", "", `filepath of binary output.`)
+	convCommand.FlagSet.BoolVar(&(c.litterEndian), "l", true, `byte order (litterEndian or BigEndian).`)
+	convCommand.FlagSet.Usage = convCommand.Usage // use default usage provided by cmds.Command.
+	cmds.AllCommands = append(cmds.AllCommands, convCommand)
+}
+
+type Conv struct {
+	input         string
+	output       string
+	litterEndian bool
+}
+
+func (c *Conv) PreRun() error {
+	if c.output == "" {
+		c.output = c.input + ".bin"
+	}
+	return nil
+}
+
+func (c *Conv) Run() error {
+	mm, err := conv(c.input)
+	if err != nil {
+		return err
+	}
+	// to CSR
+	mm.Sort()
+	rowPtr := make([]TpIndex, mm.header.numRows+1)
+	colIndex := make([]TpIndex, len(mm.data))
+	nnzs := make([]TpFloat, len(mm.data))
+	for i, ele := range mm.data {
+		if ele.row >= mm.header.numRows {
+			return errors.New("out of range when converting to CSR")
+		}
+		colIndex[i] = ele.col
+		nnzs[i] = ele.value
+		rowPtr[ele.row+1]++
+	}
+	var i TpIndex = 0
+	for ; i < mm.header.numRows; i++ {
+		nnzThisRow := rowPtr[i+1]
+		rowPtr[i+1] = rowPtr[i] + nnzThisRow
+	}
+
+	// write binary
+	if outfile, err := os.Create(c.output); err != nil {
+		return err
+	} else {
+		var byteOrder binary.ByteOrder = binary.LittleEndian
+		if !c.litterEndian {
+			byteOrder = binary.BigEndian
+		}
+		if err := binary.Write(outfile, byteOrder, &(mm.header.numRows)); err != nil {
+			return err
+		}
+		if err := binary.Write(outfile, byteOrder, &(mm.header.numColumns)); err != nil {
+			return err
+		}
+		if err := binary.Write(outfile, byteOrder, &(mm.header.numNonZeroes)); err != nil {
+			return err
+		}
+		if err := binary.Write(outfile, byteOrder, rowPtr); err != nil {
+			return err
+		}
+		if err := binary.Write(outfile, byteOrder, colIndex); err != nil {
+			return err
+		}
+		if err := binary.Write(outfile, byteOrder, nnzs); err != nil {
+			return err
+		}
+	}
+	return nil
+}

--- a/tools/suitesparse-dl/conv/mm_parser.go
+++ b/tools/suitesparse-dl/conv/mm_parser.go
@@ -1,0 +1,254 @@
+package conv
+
+import (
+	"bufio"
+	"bytes"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"sort"
+	"strings"
+)
+
+type TpIndex int32
+type TpFloat float64
+
+type Entry struct {
+	row   TpIndex
+	col   TpIndex
+	value TpFloat
+}
+
+type Entries []Entry
+
+func (e Entries) Len() int {
+	return len(e)
+}
+
+func (e Entries) Swap(i, j int) {
+	e[i], e[j] = e[j], e[i]
+}
+
+func (e Entries) Less(i, j int) bool {
+	if e[i].row != e[j].row {
+		return e[i].row < e[j].row
+	}
+	return e[i].col < e[j].col
+}
+
+// MMHeader contains the header descriptor of matrix market
+type MMHeader struct {
+	numRows      TpIndex
+	numColumns   TpIndex
+	numNonZeroes TpIndex // nnz in file body.
+	pattern      bool
+	hermitian    bool
+	complex      bool
+	symmetric    bool
+}
+
+type MatrixMarket struct {
+	header MMHeader
+	data   Entries
+}
+
+func (mm *MatrixMarket) Sort() {
+	sort.Sort(mm.data)
+}
+
+// read matrix market file and convert to csr binary file.
+func conv(filepath string) (*MatrixMarket, error) {
+	f, err := os.Open(filepath)
+	if err != nil {
+		return nil, err
+	}
+
+	// read header
+	reader := bufio.NewReader(f)
+	header, lineCounter, err := parseHeader(reader, filepath)
+	if err != nil {
+		return nil, err
+	}
+
+	reserve := header.numNonZeroes
+	if header.symmetric || header.hermitian {
+		reserve *= 2
+	}
+
+	// read body
+	data := make([]Entry, 0, reserve)
+	var read, nnzDia TpIndex
+	for {
+		line, err := reader.ReadString('\n')
+		if err != nil {
+			if err == io.EOF {
+				break
+			} else {
+				return nil, err
+			}
+		}
+		lineCounter++
+		if entry1, entry2, err := parseBodyLine(line, filepath, *header, lineCounter, &nnzDia, &read); err != nil {
+			return nil, err
+		} else {
+			// add elements to results list.
+			if entry1 != nil {
+				data = append(data, *entry1)
+			}
+			if entry2 != nil {
+				data = append(data, *entry2)
+			}
+		}
+	}
+	// assert read count.
+	if read+nnzDia != reserve {
+		return nil, fmt.Errorf("mismatch non-zeros number, expect %d, but got %d", reserve, read)
+	}
+	return &MatrixMarket{header: *header, data: data}, nil
+}
+
+func parseHeader(reader *bufio.Reader, filename string) (*MMHeader, TpIndex, error) {
+	// parse the first line
+	line, err := reader.ReadString('\n')
+	if err != nil {
+		return nil, 0, err
+	}
+
+	if len(line) < 32 || line[:32] != "%%MatrixMarket matrix coordinate" {
+		return nil, 0, errors.New("can only read MatrixMarket format that is in coordinate form")
+	}
+
+	tokens := strings.Split(strings.TrimSpace(line), " ")
+	if len(tokens) < 5 {
+		return nil, 0, errors.New("bad market matrix  header")
+	}
+
+	header := MMHeader{
+		numRows:      0,
+		numColumns:   0,
+		numNonZeroes: 0,
+		pattern:      false,
+		hermitian:    false,
+		complex:      false,
+		symmetric:    false,
+	}
+
+	if tokens[3] == "pattern" {
+		header.pattern = true
+	} else if tokens[3] == "complex" {
+		header.complex = true
+	} else if tokens[3] != "real" { // todo: only for real type.
+		return &header, 0, errors.New("MatrixMarket data type does not match matrix format")
+	}
+
+	if tokens[4] == "general" {
+		header.symmetric = false
+		header.hermitian = false
+	} else if tokens[4] == "symmetric" {
+		header.symmetric = true
+	} else if tokens[4] == "Hermitian" {
+		header.hermitian = true
+	} else {
+		return nil, 0, errors.New("can only read MatrixMarket format that is either symmetric, general or hermitian")
+	}
+
+	var lineCounter TpIndex
+	lineCounter = 0
+	// skip comments and read metadata.
+	for {
+		line2, err := reader.ReadString('\n')
+		lineCounter++
+		if err != nil {
+			return nil, 0, err
+		}
+		if len(line2) == 0 {
+			continue
+		}
+
+		// skip header
+		if line2[0] == '%' {
+			continue
+		}
+
+		lineBuffer := bytes.Buffer{}
+		lineBuffer.WriteString(line2)
+
+		var rows, columns, nnz TpIndex
+		if n, err := fmt.Fscanln(&lineBuffer, &rows, &columns, &nnz); err != nil {
+			return nil, 0, err
+		} else if n == 0 {
+			return nil, 0, fmt.Errorf("failed to read matrix market header from `%s`", filename)
+		}
+
+		header.numRows = rows
+		header.numColumns = columns
+		header.numNonZeroes = nnz
+		// fmt.Println("Read matrix header")
+		// fmt.Println("rows: ", rows, " columns: ", columns, " nnz: ", nnz)
+		break
+	}
+	return &header, lineCounter, nil
+}
+
+// parseBodyLine parses a line of body of matrix market file
+// returning at most 2 elements (If the matrix is symmetric or hermitian, it may return 2 elements).
+func parseBodyLine(line, filename string, header MMHeader, lineCounter TpIndex, nnzDia, read *TpIndex) (*Entry, *Entry, error) {
+	if len(line) == 0 {
+		return nil, nil, nil
+	}
+	if line[0] == '%' {
+		return nil, nil, nil
+	}
+
+	r, c, value, err := parseLineValue(line, header.pattern)
+	if err != nil {
+		return nil, nil, fmt.Errorf("failed to read data at line %d from matrix market file %s", lineCounter, filename)
+	}
+
+	if r > header.numRows {
+		return nil, nil, fmt.Errorf("row index out of bounds at line %d in matrix market file %s", lineCounter, filename)
+	}
+	if c > header.numColumns {
+		return nil, nil, fmt.Errorf("column index out of bounds at line %d  in matrix market file %s", lineCounter, filename)
+	}
+
+	entry1 := Entry{row: r - 1, col: c - 1, value: value}
+	*read++
+	if (header.symmetric || header.hermitian) && r == c {
+		*nnzDia++
+	}
+
+	if (header.symmetric || header.hermitian) && r != c {
+		entry2 := Entry{row: c - 1, col: r - 1, value: value} // exchange row and column.
+		*read++
+		return &entry1, &entry2, nil
+	} else {
+		return &entry1, nil, nil
+	}
+}
+
+func parseLineValue(line string, pattern bool) (TpIndex, TpIndex, TpFloat, error) {
+	lineBuffer := bytes.Buffer{}
+	lineBuffer.WriteString(strings.TrimSpace(line))
+
+	var row, col TpIndex
+	var value TpFloat
+
+	var n int
+	var err error
+	if pattern {
+		n, err = fmt.Fscanln(&lineBuffer, &row, &col)
+		value = 1.0
+	} else {
+		n, err = fmt.Fscanln(&lineBuffer, &row, &col, &value)
+	}
+
+	// check error
+	if err != nil {
+		return 0, 0, 0.0, err
+	} else if n == 0 {
+		return 0, 0, 0.0, fmt.Errorf("failed to read matrix market header")
+	}
+	return row, col, value, nil
+}

--- a/tools/suitesparse-dl/fetch/fetch.go
+++ b/tools/suitesparse-dl/fetch/fetch.go
@@ -2,6 +2,7 @@ package fetch
 
 import (
 	"bytes"
+	"encoding/json"
 	"flag"
 	"fmt"
 	"github.com/genshen/cmds"
@@ -76,6 +77,7 @@ func (f *fetch) Run() error {
 				mat.DlLinks.MatrixMarket, mat.DlLinks.Matlab, mat.DlLinks.RutherfordBoeing)); err != nil {
 				return err
 			}
+		}
 
 		// dump to json
 		if metaJsonBytes, err := json.Marshal(matMates); err != nil {
@@ -85,7 +87,7 @@ func (f *fetch) Run() error {
 			if err != nil {
 				return err
 			}
-			defer out.Close()
+			defer jsonFile.Close()
 
 			if _, err := jsonFile.Write(metaJsonBytes); err != nil {
 				return err


### PR DESCRIPTION
add suitesparse-dl sub-command `conv` to conver matrix market to binary csr format.