### PR TITLE
feat(cli): support to read csr-binary format generated by `suitesparee-dl conv` sub-command

### DIFF
--- a/benchmark/main.cpp
+++ b/benchmark/main.cpp
@@ -13,6 +13,7 @@
 #include "api/types.h"
 #include "clipp.h"
 
+#include "csr_binary_reader.hpp"
 #include "csr_mtx_reader.hpp"
 #include "matrix_market_reader.hpp"
 #include "sparse_format.h"
@@ -50,6 +51,20 @@ int main(int argc, char **argv) {
     // array data in `h_csr` is keep in instance `csr_reader`.
     csr_reader.as_raw_ptr(h_csr.values, h_csr.col_index, h_csr.row_ptr, h_vectors.hX);
     create_host_data(h_csr, h_vectors);
+    test_spmv(mtx_path, h_csr, h_vectors);
+    destroy_host_data(h_vectors);
+  } else if (fmt == "bin") {
+    csr_binary_reader<int32_t, dtype> csr_bin_reader;
+    csr_bin_reader.load_mat(mtx_path);
+    csr_bin_reader.close_stream();
+
+    h_csr.rows = csr_bin_reader.rows();
+    h_csr.cols = csr_bin_reader.cols();
+    h_csr.nnz = csr_bin_reader.nnz();
+    // just reuse memory in file reading step.
+    csr_bin_reader.as_raw_ptr(h_csr.values, h_csr.col_index, h_csr.row_ptr);
+
+    create_host_data(h_csr, h_vectors, true);
     test_spmv(mtx_path, h_csr, h_vectors);
     destroy_host_data(h_vectors);
   } else {

--- a/benchmark/main.cpp
+++ b/benchmark/main.cpp
@@ -26,10 +26,11 @@ void test_spmv(std::string mtx_path, type_csr h_csr, host_vectors<dtype> h_vecto
 int main(int argc, char **argv) {
   std::string mtx_path = "", fmt = "csr";
 
-  auto cli =
-      (clipp::value("input file", mtx_path),
-       clipp::option("-f", "--format").doc("input matrix format, can be `csr` (default) or `mm` (matrix market)") &
-           clipp::value("format", fmt));
+  auto cli = (clipp::value("input file", mtx_path),
+              clipp::option("-f", "--format")
+                      .doc("input matrix format, can be `csr` (default), `mm` (matrix market) or "
+                           "`bin` (csr binary)") &
+                  clipp::value("format", fmt));
 
   if (!parse(argc, argv, cli)) {
     std::cout << clipp::make_man_page(cli, argv[0]);

--- a/cli/csr_binary_reader.hpp
+++ b/cli/csr_binary_reader.hpp
@@ -1,0 +1,62 @@
+//
+// Created by genshen on 2021/11/28.
+//
+
+#ifndef SPMV_ACC_CSR_BINARY_READER_HPP
+#define SPMV_ACC_CSR_BINARY_READER_HPP
+
+#include <fstream>
+#include <iostream>
+#include <sstream>
+#include <stdexcept>
+#include <string>
+#include <vector>
+
+#include <api/types.h>
+
+/**
+ * Class `csr_binary_reader` read csr binary format sparse matrix from file to memory.
+ * @tparam I type of integer
+ * @tparam T type of float number data
+ */
+template <typename I, typename T> class csr_binary_reader : public var_csr_desc<I, T> {
+  typedef var_csr_desc<I, T> P;
+  typedef char *BytePtr;
+
+public:
+  I rows() { return P::rows; }
+  I cols() { return P::cols; }
+  I nnz() { return P::nnz; }
+
+  void as_raw_ptr(T *&_value, I *&_col_index, I *&_row_ptr) {
+    _value = P::values;
+    _col_index = P::col_index;
+    _row_ptr = P::row_ptr;
+  }
+
+  void load_mat(const std::string &mtx_path) {
+    std::ifstream fin(mtx_path, std::ios::in | std::ios::binary);
+    if (!fin.good()) {
+      std::cerr << "file open failed, file: " << mtx_path << std::endl;
+      return;
+    }
+    fin.read((BytePtr)(&(P::rows)), sizeof(I)); // todo: make sure storage type is 4 bytes.
+    fin.read((BytePtr)(&(P::cols)), sizeof(I));
+    fin.read((BytePtr)(&(P::nnz)), sizeof(I));
+
+    P::row_ptr = new I[P::rows + 1];
+    P::col_index = new I[P::nnz];
+    P::values = new T[P::nnz];
+
+    fin.read((BytePtr)(P::row_ptr), sizeof(I) * (P::rows + 1));
+    fin.read((BytePtr)(P::col_index), sizeof(I) * P::nnz);
+    fin.read((BytePtr)(P::values), sizeof(T) * P::nnz);
+    fin.close();
+  }
+
+  void close_stream() {
+    // nothing to do, just keep the same api as csr text reader
+  }
+};
+
+#endif // SPMV_ACC_CSR_BINARY_READER_HPP

--- a/cli/main.cpp
+++ b/cli/main.cpp
@@ -33,10 +33,11 @@ void test_spmv(std::string mtx_path, type_csr h_csr, host_vectors<dtype> h_vecto
 int main(int argc, char **argv) {
   std::string mtx_path = "", fmt = "csr";
 
-  auto cli =
-      (clipp::value("input file", mtx_path),
-       clipp::option("-f", "--format").doc("input matrix format, can be `csr` (default) or `mm` (matrix market)") &
-           clipp::value("format", fmt));
+  auto cli = (clipp::value("input file", mtx_path),
+              clipp::option("-f", "--format")
+                      .doc("input matrix format, can be `csr` (default), `mm` (matrix market) or "
+                           " `bin` (csr binary)") &
+                  clipp::value("format", fmt));
 
   if (!parse(argc, argv, cli)) {
     std::cout << clipp::make_man_page(cli, argv[0]);


### PR DESCRIPTION
support to read csr-binary format generated by `suitesparee-dl conv` sub-command in `benchmark` and `cli` executable.
To read matrix file as csr-binary format, user can specific the argument `-f bin` or `--format bin` 