### PR TITLE
Fix building errors of hola-hip

### DIFF
--- a/benchmark/hola-hip/hola-hip_source_list.cmake
+++ b/benchmark/hola-hip/hola-hip_source_list.cmake
@@ -1,5 +1,5 @@
 set(SP_LIB_HEADER ${SP_LIB_HEADER}
-        ${SP_LIB_SRC_BASE}/spmv.h
+        ${SP_LIB_SRC_BASE}/hola-hip/spmv.h
         ${CMAKE_SOURCE_DIR}/third-party/holahip/hip-hola/d_csr.h
         ${CMAKE_SOURCE_DIR}/third-party/holahip/hip-hola/hola_vector.h
         ${CMAKE_SOURCE_DIR}/third-party/holahip/hip-hola/hola_spmv.h

--- a/benchmark/sparse.cmake
+++ b/benchmark/sparse.cmake
@@ -24,6 +24,6 @@ target_link_libraries(
 target_include_directories(
     ${SPMV_BENCHMARK_SPARSE_LIB}
     PUBLIC
-    $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}<SEMICOLON>${CMAKE_SOURCE_DIR}/third-party/holahip/hip-hola$<SEMICOLON>${CMAKE_SOURCE_DIR}/third-party/holaspmv$<SEMICOLON>${PROJECT_BINARY_DIR}/generated>
+    $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}$<SEMICOLON>${CMAKE_SOURCE_DIR}/third-party/holahip/hip-hola$<SEMICOLON>${CMAKE_SOURCE_DIR}/third-party/holaspmv$<SEMICOLON>${PROJECT_BINARY_DIR}/generated>
     $<INSTALL_INTERFACE:include>
 )

--- a/third-party/get_hola_hip.sh
+++ b/third-party/get_hola_hip.sh
@@ -1,12 +1,14 @@
 #!/bin/sh
+set -e
+
 #this file is used for load hola from git.hpcer.dev or github
 
 # or mirror from: https://github.com/hpcde/hola-hip.git
 git clone https://git.hpcer.dev/PRA/hola-hip.git holahip
 
 cd holahip
-git checkout 20b1669b9c397aca8f629099eb70890c53940da0
+git checkout 08a2b06ceb5b5605dabf6842b90ab63b931a5607
 
 echo "completed."
-echo -e "\033[31m Please edit file hip-hola/utils/common.hpp to set the WARP_SIZE to the desired value
+echo "\033[31m Please edit file holahip/hip-hola/utils/common.hpp to set the WARP_SIZE to the desired value
 (usually 32 for NVIDIA GPU and 64 for AMD GPU). \033[0m" 


### PR DESCRIPTION
This PR includes:
- bump hola-hip version to fix building errors from `hipFree` and `CSR<double>` template.  
- Fix typos and wrong path in benchmark make script.
