### PR TITLE
Fix benchmark building and testing

### DIFF
--- a/.chglog/config.yml
+++ b/.chglog/config.yml
@@ -2,7 +2,7 @@ style: github
 template: CHANGELOG.tpl.md
 info:
   title: CHANGELOG
-  repository_url: https://git.hpcer.dev/PRA/spmv-acc
+  repository_url: https://github.com/hpcde/spmv-acc
 options:
   commits:
     # filters:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,126 @@
 ## [Unreleased]
 
 
+<a name="v0.6.0"></a>
+## [v0.6.0] - 2022-03-01
+### Build
+- **cmake:** support OpenMP for benchmark executable target when performing linking
+- **cmake:** reorganize benchmark device-side libs and pass the missing HIP_NVCC_FLAGS to flat src
+- **cmake:** add a cmake option `SPMV_BUILD_BENCHMARK` to disable/enable benchmark building
+- **cmake:** reorganize cmake script under directory benchmark
+- **cmake:** add cmake config for benchmark executable binary
+- **cmake:** set CXX standard to 14 for using std::unique_ptr
+- **cmake:** move clipp.h header to directory `third-party`
+
+### Docs
+- **readme:** add document of fetching dependency `clipp`
+- **suitesparse-dl:** add document for "matrices with the same name"
+- **suitesparse-dl:** add document of extracting matrix market from .tar.gz file
+
+### Feat
+- correctly access row_offset when device row_offset accessing on host side is not supported
+- **benchmark:** add benchmark support for SpMV-acc strategies and cuSPARSE in func `test_spmv`
+- **benchmark:** more strong verification for benchmark
+- **benchmark:** throw runtime_error of hola device SpMV
+- **benchmark:** record preproc time, calc time and destroy time in statistics data
+- **benchmark:** add the adaptive line kernel to benchmark
+- **benchmark:** record strategy name in statistics data
+- **benchmark:** benchmark support for rocsparse SpMV: vector and csr-adaptive
+- **benchmark:** benchmark support for hola CsrMV on hip
+- **benchmark:** benchmark support for hola CsrMV on Cuda
+- **benchmark:** destory host/device data after test
+- **benchmark:** disable benchmarking the default sequential spmv method on device side
+- **benchmark:** verify after outputting statistics
+- **benchmark:** change style of performance statistics log: split header and data
+- **benchmark:** benchmark support for cub CsrMV on Cuda
+- **cli:** add OpenMP support to matrix-market input parsing
+- **cli:** update the cli and benchmark help message: value of `-f` can be `bin`
+- **cli:** add OpenMP support for data sorting when converting COO to CSR
+- **cli:** support to read csr-binary format converted by `suitesparse-dl conv` sub-command
+- **cli:** use clipp to parse command line argument
+- **cli:** show more detailed error message in HIP_CHECK macro
+- **cli:** add matrix market format reading support
+- **common:** support reduction on CUDA platform and make DPP reduction available only on ROCm
+- **common:** add compatible code to make nontemporal-load/store, fma and atomicAdd work on nvidia
+- **common:** mv data-load assembly to `platform/rocm` and add compatible data loading code for CUDA
+- **kernel-light:** support the case of "wrap size is 32" (Nvidia GPU) for light strategy
+- **kernel-line:** replace the origin line method with adaptive-line method
+- **kernel-line:** adjust the value of ROW_NUM in adaptive line calculation
+- **kernel-line:** add adaptive line-kerenel: switch between line and vector-row
+- **kernel-line:** combine the LDS space used by line and vector-row algorithm in adaptive line
+- **kernel-line-enhance:** support memory coalescing in vector reduction when storing data back
+- **kernel-line-enhance:** add a static assert to check vector number and rows assigned to a block
+- **kernel-vector-row:** support to move data from thread 0 of vectors to front lanes on CUDA
+- **kernel-vertor-row:** support the case of "wrap size is 32" (Nvidia GPU)
+- **scripts:** add a compiler wrapper to remove unrecognized argument `-std=gnu++14` for nvcc
+- **suitesparse-dl:** download matrices into different NNZ categories
+- **suitesparse-dl:** support to convert matrix market format to binary CSR file format
+- **suitesparse-dl:** add feature of generating sbatch file from matrices data for job submitting
+- **suitesparse-dl:** add `fetch` subcommand for fetching collection metadata
+- **suitesparse-dl:** add cli flags parsing and use `dl` sub-command for downloading
+- **suitesparse-dl:** add cli flags to specific data dir and goroutines for downloading
+- **suitesparse-dl:** support to convert matrix with integer type as value
+- **suitesparse-dl:** stop downloading if there is any error in downloading process
+- **suitesparse-dl:** skip the matrix downloading if the file exists
+- **suitesparse-dl:** download matrix to temporary file and then rename to the final file
+- **suitesparse-dl:** add a tool for downloading matrices of matrix market format from SuiteSparse
+- **third-party:** add a prompt to set the WARP_SIZE after downloaded hip-hola
+- **third-party:** specific version and apply changes when or after downloading hola
+
+### Fix
+- **benchmark:** correct verification for cub and hola spmv which only compute y=Ax
+- **benchmark:** fix cub SpMV invalid device function
+- **cli:** fix incorrect nnz assertion while reading matrix market format
+- **cli:** fix Segmentation fault while using csr matrix data after variable `csr_reader` is released
+- **cmake:** fix typos and incorrect path in benchmark cmake script to make hola-hip compiling passed
+- **compile:** correct possible compiling error `error: size of array 'buf' is negative`
+- **compile:** fix possible compiling error of `determining template type` under some compilers
+- **compile:** fix compiling errors in benchmark and cli building
+- **compile:** fix compiling issues (with OpenMP support) on nvidia platform
+- **compile:** add the missing template param for func `dpp_wf_reduce_sum` on ROCm platform
+- **demo:** fix possible crash when allocing buffer memory for csr file reading in demo
+- **kernel-flat:** fix compiling error: `flat_sparse_spmv` declaration does not match the definition
+- **kernel-line:** fix incorrect data storing logic of vector-row method in adaptive line
+- **kernel-line-enhance:** fix the possible stucked vector-based reduction on NVIDIA platform
+- **suitesparse-dl:** fix incorrect "NNZ" values stored into binary csr file header
+- **suitesparse-dl:** fix compiling errors in `fetch` sub-command
+- **suitesparse-dl:** fix parsing error when the matrix data type is complex
+- **third-party:** bump hola-hip version to fix building errors from `hipFree` and `CSR<double>` template
+
+### Merge
+- Merge pull request [#35](https://github.com/hpcde/spmv-acc/issues/35) from hpcde/fix-hola-hip-building-errors
+- Merge pull request [#25](https://github.com/hpcde/spmv-acc/issues/25) from hpcde/feature-nvidia-support
+- Merge pull request [#27](https://github.com/hpcde/spmv-acc/issues/27) from hpcde/fix-error-of-nvidia-support
+- **benchmark:** Merge pull request [#28](https://github.com/hpcde/spmv-acc/issues/28) from hpcde/feature-benchmark
+- **benchmark:** Merge pull request [#36](https://github.com/hpcde/spmv-acc/issues/36) from hpcde/enhanced-HIP_CHECK-and-verify-for-cli-and-benchmark
+- **benchmark:** Merge pull request [#30](https://github.com/hpcde/spmv-acc/issues/30) from hpcde/benchmarks-improves
+- **cli:** Merge pull request [#26](https://github.com/hpcde/spmv-acc/issues/26) from hpcde/feature-openmp-matrix-market-reading
+- **cli:** Merge pull request [#31](https://github.com/hpcde/spmv-acc/issues/31) from hpcde/feature-csr-binary-reader
+- **cli:** Merge pull request [#22](https://github.com/hpcde/spmv-acc/issues/22) from hpcde/feature-matrix_market_support
+- **kernel-line:** Merge pull request [#32](https://github.com/hpcde/spmv-acc/issues/32) from hpcde/feature-adaptive-line
+- **kernel-line-enhance:** Merge pull request [#34](https://github.com/hpcde/spmv-acc/issues/34) from hpcde/fix-line-enhance-shlf_down-reduce-stucked
+- **kernel-line-enhance:** Merge pull request [#37](https://github.com/hpcde/spmv-acc/issues/37) from hpcde/opt-line-enhance-vector-reduction
+- **suitesparse-dl:** Merge pull request [#33](https://github.com/hpcde/spmv-acc/issues/33) from hpcde/hotfix-suitesparse-dl-conv
+- **suitesparse-dl:** Merge pull request [#24](https://github.com/hpcde/spmv-acc/issues/24) from hpcde/feature-suitesparse-dl-sbatch-gen
+- **suitesparse-dl:** merge: Merge pull request [#23](https://github.com/hpcde/spmv-acc/issues/23) from hpcde/feature-suitesparse-downloader
+
+### Perf
+- **cli:** remove unnecessary data copy when converting matrix-market to CSR
+- **cli:** replace stringstream with user-customized line parser to parse matrix-market format
+- **cli:** read the whole file into buffer and than parse while loading matrix-market format
+- **kernel-line-enhance:** move a part of sum reduction (local & global shift) to out of rounds-loop
+
+### Refactor
+- **benchmark:** apply a simpler approach to benchmark different algorithms
+- **cli:** refactor code of matrix-market reading and parsing: split header and body reading
+- **cli:** move implementation code of verification.h to cpp file
+- **cli:** rename class mtx_reader -> csr_mtx_reader, file csr.hpp -> sparse_format.h
+- **kernel-line:** use param BLOCK_LDS_SIZE, rather than MAX_ROW_NNZ, to specific LDS size
+
+### Pull Requests
+- Merge pull request [#29](https://github.com/hpcde/spmv-acc/issues/29) from hpcde/feature-suitesparse-dl-binary-csr-convert
+
+
 <a name="v0.5.0"></a>
 ## [v0.5.0] - 2021-10-15
 ### Chore

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -139,8 +139,8 @@
 
 ### Merge
 - **kernel-adaptive:** Merge branch 'revert-adaptive-line-enhance-case' into branch main
-- **kernel-adaptive:** Merge pull request [#20](https://git.hpcer.dev/PRA/spmv-acc/issues/20) from hpcde/feature-adaptive-line-enhance
-- **kernel-adaptive:** Merge pull request [#19](https://git.hpcer.dev/PRA/spmv-acc/issues/19) from hpcde/feature-kernel-line-for-short-row-matrix
+- **kernel-adaptive:** Merge pull request [#20](https://github.com/hpcde/spmv-acc/issues/20) from hpcde/feature-adaptive-line-enhance
+- **kernel-adaptive:** Merge pull request [#19](https://github.com/hpcde/spmv-acc/issues/19) from hpcde/feature-kernel-line-for-short-row-matrix
 
 ### Revert
 - **kernel-adaptive:** don't use adaptive line-enhance if a large matrix has short rows
@@ -174,14 +174,14 @@
 - **kernel-flat:** correct the wrong length of array `break_points`
 
 ### Merge
-- Merge pull request [#14](https://git.hpcer.dev/PRA/spmv-acc/issues/14) from hpcde/feature-more-flexible-configs
-- **cli:** Merge pull request [#11](https://git.hpcer.dev/PRA/spmv-acc/issues/11) from hpcde/feature-new-cli
-- **cmake:** Merge pull request [#12](https://git.hpcer.dev/PRA/spmv-acc/issues/12) from hpcde/fix-cmake-find-omp
-- **kernel-flat:** Merge pull request [#10](https://git.hpcer.dev/PRA/spmv-acc/issues/10) from hpcde/feature-kernel-flat-vec-reduction
-- **kernel-flat:** Merge pull request [#13](https://git.hpcer.dev/PRA/spmv-acc/issues/13) from hpcde/feature-kernel-flat-one-pass
-- **kernel-line:** Merge pull request [#15](https://git.hpcer.dev/PRA/spmv-acc/issues/15) from hpcde/feature-kernel-line-one-pass
-- **kernel-line-enhance:** Merge pull request [#18](https://git.hpcer.dev/PRA/spmv-acc/issues/18) from hpcde/feature-kernel-strategy-line-enhance
-- **tools:** Merge pull request [#16](https://git.hpcer.dev/PRA/spmv-acc/issues/16) from hpcde/feature-csr-tool-block-nnz
+- Merge pull request [#14](https://github.com/hpcde/spmv-acc/issues/14) from hpcde/feature-more-flexible-configs
+- **cli:** Merge pull request [#11](https://github.com/hpcde/spmv-acc/issues/11) from hpcde/feature-new-cli
+- **cmake:** Merge pull request [#12](https://github.com/hpcde/spmv-acc/issues/12) from hpcde/fix-cmake-find-omp
+- **kernel-flat:** Merge pull request [#10](https://github.com/hpcde/spmv-acc/issues/10) from hpcde/feature-kernel-flat-vec-reduction
+- **kernel-flat:** Merge pull request [#13](https://github.com/hpcde/spmv-acc/issues/13) from hpcde/feature-kernel-flat-one-pass
+- **kernel-line:** Merge pull request [#15](https://github.com/hpcde/spmv-acc/issues/15) from hpcde/feature-kernel-line-one-pass
+- **kernel-line-enhance:** Merge pull request [#18](https://github.com/hpcde/spmv-acc/issues/18) from hpcde/feature-kernel-strategy-line-enhance
+- **tools:** Merge pull request [#16](https://github.com/hpcde/spmv-acc/issues/16) from hpcde/feature-csr-tool-block-nnz
 
 ### Perf
 - **cli:** add OpenMP support for the new cli to parse the input matrix
@@ -200,7 +200,7 @@
 - **kernel-line-enhance:** move direct reduction to a new func `line_enhance_direct_reduce`
 
 ### Pull Requests
-- Merge pull request [#17](https://git.hpcer.dev/PRA/spmv-acc/issues/17) from hpcde/feature-adaptive-flat
+- Merge pull request [#17](https://github.com/hpcde/spmv-acc/issues/17) from hpcde/feature-adaptive-flat
 
 
 <a name="v0.4.0"></a>
@@ -235,18 +235,18 @@
 - **kernel-vector-row:** fix the wrong kernel func called in native vector-row while VECTOR_SIZE is 8
 
 ### Merge
-- Merge pull request [#4](https://git.hpcer.dev/PRA/spmv-acc/issues/4) from hpcde/fix-flat-and-vector-row-bugs
+- Merge pull request [#4](https://github.com/hpcde/spmv-acc/issues/4) from hpcde/fix-flat-and-vector-row-bugs
 - Merge branch 'cmake-enable-build-all-strategies' into 'main'
-- **kernel-adaptive:** Merge pull request [#1](https://git.hpcer.dev/PRA/spmv-acc/issues/1) from hpcde/feature-kernel-adaptive into branch main
-- **kernel-flat:** Merge pull request [#2](https://git.hpcer.dev/PRA/spmv-acc/issues/2) from hpcde/opt-on-kernel-flat
-- **kernel-thread-row:** Merge pull request [#9](https://git.hpcer.dev/PRA/spmv-acc/issues/9) from hpcde/feat-thread-row-single
-- **kernel-thread-row:** Merge pull request [#6](https://git.hpcer.dev/PRA/spmv-acc/issues/6) from hpcde/opt-thread-row-in-block-level
-- **kernel-thread-row:** Merge pull request [#8](https://git.hpcer.dev/PRA/spmv-acc/issues/8) from hpcde/opt-thread-row-tune-kernel-config
-- **kernel-thread-row:** Merge pull request [#7](https://git.hpcer.dev/PRA/spmv-acc/issues/7) from hpcde/opt-thread-row-in-block-level-x-remap
+- **kernel-adaptive:** Merge pull request [#1](https://github.com/hpcde/spmv-acc/issues/1) from hpcde/feature-kernel-adaptive into branch main
+- **kernel-flat:** Merge pull request [#2](https://github.com/hpcde/spmv-acc/issues/2) from hpcde/opt-on-kernel-flat
+- **kernel-thread-row:** Merge pull request [#9](https://github.com/hpcde/spmv-acc/issues/9) from hpcde/feat-thread-row-single
+- **kernel-thread-row:** Merge pull request [#6](https://github.com/hpcde/spmv-acc/issues/6) from hpcde/opt-thread-row-in-block-level
+- **kernel-thread-row:** Merge pull request [#8](https://github.com/hpcde/spmv-acc/issues/8) from hpcde/opt-thread-row-tune-kernel-config
+- **kernel-thread-row:** Merge pull request [#7](https://github.com/hpcde/spmv-acc/issues/7) from hpcde/opt-thread-row-in-block-level-x-remap
 - **kernel-vector-row:** Merge branch 'enhance-vector-row' into feature-kernel-adaptive
-- **kernel-vector-row:** Merge pull request [#3](https://git.hpcer.dev/PRA/spmv-acc/issues/3) from hpcde/opt-vector-row-access-y-coalescing
+- **kernel-vector-row:** Merge pull request [#3](https://github.com/hpcde/spmv-acc/issues/3) from hpcde/opt-vector-row-access-y-coalescing
 - **kernel-vector-row:** Merge branch 'enhance-vector-row' into 'main'
-- **thread-row:** Merge pull request [#5](https://git.hpcer.dev/PRA/spmv-acc/issues/5) from hpcde/opt-thread-row-remap-vec_x
+- **thread-row:** Merge pull request [#5](https://github.com/hpcde/spmv-acc/issues/5) from hpcde/opt-thread-row-remap-vec_x
 
 ### Perf
 - **kernel-flat:** move barrier __syncthreads() ahead(moved to the place before loading matrix data)
@@ -519,14 +519,15 @@
 - **kernel-wf-row-reg:** removed unused code
 
 
-[Unreleased]: https://git.hpcer.dev/PRA/spmv-acc/compare/v0.5.0...HEAD
-[v0.5.0]: https://git.hpcer.dev/PRA/spmv-acc/compare/stash_flat_preprocess...v0.5.0
-[stash_flat_preprocess]: https://git.hpcer.dev/PRA/spmv-acc/compare/v0.4.0...stash_flat_preprocess
-[v0.4.0]: https://git.hpcer.dev/PRA/spmv-acc/compare/v0.3.0...v0.4.0
-[v0.3.0]: https://git.hpcer.dev/PRA/spmv-acc/compare/v0.2.4...v0.3.0
-[v0.2.4]: https://git.hpcer.dev/PRA/spmv-acc/compare/v0.2.3...v0.2.4
-[v0.2.3]: https://git.hpcer.dev/PRA/spmv-acc/compare/v0.2.2...v0.2.3
-[v0.2.2]: https://git.hpcer.dev/PRA/spmv-acc/compare/v0.2.1...v0.2.2
-[v0.2.1]: https://git.hpcer.dev/PRA/spmv-acc/compare/v0.2.0...v0.2.1
-[v0.2.0]: https://git.hpcer.dev/PRA/spmv-acc/compare/v0.1.1...v0.2.0
-[v0.1.1]: https://git.hpcer.dev/PRA/spmv-acc/compare/v0.1.0...v0.1.1
+[Unreleased]: https://github.com/hpcde/spmv-acc/compare/v0.6.0...HEAD
+[v0.6.0]: https://github.com/hpcde/spmv-acc/compare/v0.5.0...v0.6.0
+[v0.5.0]: https://github.com/hpcde/spmv-acc/compare/stash_flat_preprocess...v0.5.0
+[stash_flat_preprocess]: https://github.com/hpcde/spmv-acc/compare/v0.4.0...stash_flat_preprocess
+[v0.4.0]: https://github.com/hpcde/spmv-acc/compare/v0.3.0...v0.4.0
+[v0.3.0]: https://github.com/hpcde/spmv-acc/compare/v0.2.4...v0.3.0
+[v0.2.4]: https://github.com/hpcde/spmv-acc/compare/v0.2.3...v0.2.4
+[v0.2.3]: https://github.com/hpcde/spmv-acc/compare/v0.2.2...v0.2.3
+[v0.2.2]: https://github.com/hpcde/spmv-acc/compare/v0.2.1...v0.2.2
+[v0.2.1]: https://github.com/hpcde/spmv-acc/compare/v0.2.0...v0.2.1
+[v0.2.0]: https://github.com/hpcde/spmv-acc/compare/v0.1.1...v0.2.0
+[v0.1.1]: https://github.com/hpcde/spmv-acc/compare/v0.1.0...v0.1.1

--- a/benchmark/csr_spmv.hpp
+++ b/benchmark/csr_spmv.hpp
@@ -67,6 +67,7 @@ struct CsrSpMV {
     for (int i = 0; i < BENCHMARK_ARRAY_SIZE; i++) {
       BenchmarkTime bmt;
       HIP_CHECK(hipMemcpy(dev_y, h_vectors.temphY, d_csr.rows * sizeof(dtype), hipMemcpyHostToDevice))
+      hipDeviceSynchronize();
       csr_spmv_impl(operation, alpha, beta, h_csr.as_const(), d_csr.as_const(), dev_x, dev_y, &bmt);
       hipDeviceSynchronize();
       bmt_array.append(bmt);
@@ -75,6 +76,7 @@ struct CsrSpMV {
     // device result check
     HIP_CHECK(hipMemcpy(dev_y, h_vectors.temphY, h_csr.rows * sizeof(dtype), hipMemcpyHostToDevice))
     csr_spmv_impl(operation, alpha, beta, h_csr.as_const(), d_csr.as_const(), dev_x, dev_y, nullptr);
+    hipDeviceSynchronize();
     HIP_CHECK(hipMemcpy(h_vectors.hY, dev_y, d_csr.rows * sizeof(dtype), hipMemcpyDeviceToHost));
 
     // host side verification

--- a/benchmark/sparse.cmake
+++ b/benchmark/sparse.cmake
@@ -24,6 +24,6 @@ target_link_libraries(
 target_include_directories(
     ${SPMV_BENCHMARK_SPARSE_LIB}
     PUBLIC
-    $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}$<SEMICOLON>${CMAKE_SOURCE_DIR}/third-party/holahip/hip-hola$<SEMICOLON>${CMAKE_SOURCE_DIR}/third-party/holaspmv$<SEMICOLON>${CMAKE_SOURCE_DIR}/third-party/holaspmv/deps/cub$<SEMICOLON>${PROJECT_BINARY_DIR}/generated>
+    $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}$<SEMICOLON>${CMAKE_SOURCE_DIR}/third-party/holahip/hip-hola$<SEMICOLON>${CMAKE_SOURCE_DIR}/third-party/holaspmv$<SEMICOLON>${CMAKE_SOURCE_DIR}/third-party/include$<SEMICOLON>${PROJECT_BINARY_DIR}/generated>
     $<INSTALL_INTERFACE:include>
 )


### PR DESCRIPTION
- add sync before launching kernel.
- add missing path `third-party/include` to cmake include dir in benchmark building.