### PR TITLE
fix(compile): fix possible compiling error under clang-12

### DIFF
--- a/cli/csr_mtx_reader.hpp
+++ b/cli/csr_mtx_reader.hpp
@@ -5,6 +5,7 @@
 #ifndef SPMV_ACC_CSR_MTX_READER_HPP
 #define SPMV_ACC_CSR_MTX_READER_HPP
 
+#include <iostream>
 #include <fstream>
 #include <sstream>
 #include <stdexcept>

--- a/cli/matrix_market_reader.hpp
+++ b/cli/matrix_market_reader.hpp
@@ -7,7 +7,9 @@
 
 #include <cstdint>
 #include <iostream>
+#include <iterator>
 #include <memory>
+#include <sstream>
 #include <stdexcept>
 #include <string>
 #include <vector>

--- a/cli/sparse_format.h
+++ b/cli/sparse_format.h
@@ -34,13 +34,13 @@ public:
 template <typename I, typename T> struct Entry {
   I r, c;
   T v;
-  bool operator<(const Entry &other) {
+  bool operator<(const Entry &other) const {
     if (r != other.r) {
       return r < other.r;
     }
     return c < other.c;
   }
-  bool operator>(const Entry &other) {
+  bool operator>(const Entry &other) const {
     if (r != other.r) {
       return r > other.r;
     }

--- a/cli/sparse_format.h
+++ b/cli/sparse_format.h
@@ -6,7 +6,9 @@
 #define SPMV_ACC_SPARSE_FORMAT_H
 
 #include <algorithm>
+#include <cstring>
 #include <memory>
+#include <string>
 #include <vector>
 
 #include "api/types.h"


### PR DESCRIPTION
Fix compiling error of:
```log
include/c++/v1/algorithm:725:71: error: invalid operands to binary expression ('const Entry<int, double>' and 'const Entry<int, double>')
  bool operator()(const _T1& __x, const _T1& __y) const {return __x < __y;}
...
sparse_format.h:23:8: note: candidate function not viable: 'this' argument has type 'const Entry<int, double>', but method is not marked const
  bool operator<(const Entry &other) {
```