### PR TITLE
fix(compile): fix compiling error in csr_binary_reader under gnu compiler

### DIFF
--- a/cli/csr_binary_reader.hpp
+++ b/cli/csr_binary_reader.hpp
@@ -40,9 +40,12 @@ public:
       std::cerr << "file open failed, file: " << mtx_path << std::endl;
       return;
     }
-    fin.read((BytePtr)(&(P::rows)), sizeof(I)); // todo: make sure storage type is 4 bytes.
-    fin.read((BytePtr)(&(P::cols)), sizeof(I));
-    fin.read((BytePtr)(&(P::nnz)), sizeof(I));
+    I &_r = P::rows;
+    I &_c = P::cols;
+    I &_nnz = P::nnz;
+    fin.read((BytePtr)(&(_r)), sizeof(I)); // todo: make sure storage type is 4 bytes.
+    fin.read((BytePtr)(&(_c)), sizeof(I));
+    fin.read((BytePtr)(&(_nnz)), sizeof(I));
 
     P::row_ptr = new I[P::rows + 1];
     P::col_index = new I[P::nnz];


### PR DESCRIPTION
Fix compiling error of (tested on CUDA 10.2 and gnu 7.4.0 platform):
```log
spmv-acc/cli/csr_binary_reader.hpp: In instantiation of 'void csr_binary_reader<I, T>::load_mat(const string&) [with I = int; T
= double; std::__cxx11::string = std::__cxx11::basic_string<char>]:
spmv-acc/cli/main.cpp:65:33: required from here
spm-acc/cli/csr_binary_reader.hpp:43:10: error: invalid cast from type 'int var_cs_desc<int,double>::**' to type 'csr_binary_reader<int, double>::BytePtr' {aka 'char*'}
fin.read((BytePtr) (&(P::rows)), sizeof (I)); // todo: make sure storage type is 4 bytes.
spmv-acc/cli/csr_binary_reader.hpp:44:10: error: invalid cast from type 'int var_csr_desc<int, doubie>::*' to type 'csr_binary_reader<int, double>::Byteptr' {aka 'char*'}
fin.read((BytePtr) (&(P::cols)), sizeof (I));
spmv-acc/cli/csr_binary_reader.hpp:45:10: error: invalid cast from type 'int var_csr_desc<int,double>::*' to type 'csr_binary_reader<int,doubles>::BytePtr'{aka 'char *'}
fin.read((BytePtr) (&(P::nnz)), sizeof (I));
```