### PR TITLE
fix(benchmark): fix building errors while building hola-hip code

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,6 +62,15 @@ cmake --build ./build-hip-adaptive
 ./build-hip-adaptive/bin/spmv-cli examples/data/rajat03.csr -f csr
 ```
 
+### Build with benchmark
+```bash
+# please remomber to change WARP_SIZE in hola-hip on rocm platform
+cmake -B ./build -S ./ \
+   -DBENCHMARK_FORCE_SYNC_KERNELS=ON -DSPMV_BUILD_BENCHMARK=ON -DSPMV_OMP_ENABLED_FLAG=ON \
+   -DCMAKE_CXX_FLAGS="-std=c++14" -DHIP_HIPCC_FLAGS="-std=c++14"
+cmake --build ./build -j 4
+```
+
 ## For Developers
 ### Add a new kernel strategy
 A **kernel strategy** is an algorithm for calculating SpMV on device side.  

--- a/benchmark/hola-hip/hola-hip_source_list.cmake
+++ b/benchmark/hola-hip/hola-hip_source_list.cmake
@@ -10,3 +10,5 @@ set(SP_LIB_SOURCE ${SP_LIB_SOURCE}
         ${HOLA_HIP_SRC_DIR}/hip-hola/hola_spmv.cpp
         ${HOLA_HIP_SRC_DIR}/hip-hola/d_csr.cpp
         )
+
+include_directories(${HOLA_HIP_SRC_DIR}/hip-hola/)


### PR DESCRIPTION
fix building errors: 1) d_csr.h file not found; 2) building requires std=c++14.
