### PR TITLE
Fix benchmark building on nvidia platform

### DIFF
--- a/benchmark/acsr/ACSR.cpp
+++ b/benchmark/acsr/ACSR.cpp
@@ -5,6 +5,7 @@
 #include "timer.h"
 #include "ACSR.h"
 #include <vector>
+#include "utils/timer_utils.h"
 
 #define BIN_MAX 30
 #define ROW_MAX 1024

--- a/benchmark/benchmark_cusparse.hpp
+++ b/benchmark/benchmark_cusparse.hpp
@@ -11,7 +11,7 @@
 
 #include "timer.h"
 #include "utils/benchmark_time.h"
-#include "benchmark/timer_utils.h"
+#include "utils/timer_utils.h"
 
 struct CuSparseGeneral : CsrSpMV {
   inline cusparseSpMVAlg_t get_spmv_algo() {

--- a/benchmark/cub/spmv.cu
+++ b/benchmark/cub/spmv.cu
@@ -8,6 +8,7 @@
 #include "api/types.h"
 #include "timer.h"
 #include "benchmark_config.h"
+#include "utils/timer_utils.h"
 
 void spmv(int trans, const csr_desc<int, double> h_csr_desc, const csr_desc<int, double> d_csr_desc, const double *x,
           double *y, BenchmarkTime *bmt) {

--- a/benchmark/merge-path/merge_path_spmv.cu
+++ b/benchmark/merge-path/merge_path_spmv.cu
@@ -11,6 +11,7 @@
 #include <utility>
 
 #include "benchmark_config.h"
+#include "utils/timer_utils.h"
 
 template <int REDUCTION_ALGORITHM, int UPDATE_ALGORITHM>
 void merge_path_spmv(int trans, const int alpha, const int beta, const csr_desc<int, double> h_csr_desc,


### PR DESCRIPTION
- fix removed/deprecated  `CUSPARSE_MV_ALG_DEFAULT` in cusparse
- fix the missing or incorrect include path of `utils/timer_utils.h`