### PR TITLE
build(cmake): add cmake presets for ROCm and CUDA platform building

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.6)
+cmake_minimum_required(VERSION 3.21)
 project(SPMV-Acc)
 
 set(CMAKE_CXX_STANDARD 14)

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -1,0 +1,127 @@
+{
+    "version": 3,
+    "cmakeMinimumRequired": {
+        "major": 3,
+        "minor": 21,
+        "patch": 0
+    },
+    "configurePresets": [
+        {
+            "name": "use-ninja",
+            "hidden": true,
+            "generator": "Ninja",
+            "cacheVariables": {
+                "CMAKE_EXPORT_COMPILE_COMMANDS": "ON"
+            }
+        },
+        {
+            "name": "default-build-dir",
+            "hidden": true,
+            "binaryDir": "${sourceDir}/build"
+        },
+
+        {
+            "name": "enable-benchmark",
+            "hidden": true,
+            "cacheVariables": {
+                "BENCHMARK_FORCE_SYNC_KERNELS": "ON",
+                "SPMV_BUILD_BENCHMARK": "ON",
+                "SPMV_OMP_ENABLED_FLAG": "ON"
+            }
+        },
+        {
+            "name": "use-platform-rocm",
+            "hidden": true,
+            "cacheVariables": {
+                "WAVEFRONT_SIZE": "64",
+                "BENCHMARK_CUDA_ENABLE_FLAG": "OFF"
+            }
+        },
+        {
+            "name": "use-platform-cuda",
+            "hidden": true,
+            "cacheVariables": {
+                "WAVEFRONT_SIZE": "32",
+                "BENCHMARK_CUDA_ENABLE_FLAG": "ON",
+                // set cuda arch here.
+                "HIP_NVCC_FLAGS": "-arch=sm_89 -rdc=true -Xcompiler -fdiagnostics-color=always"
+            }
+        },
+        {
+            "name": "use-nv-hipcc-wrapper",
+            "hidden": true,
+            "cacheVariables": {
+                "CMAKE_CXX_EXTENSIONS": "OFF",
+                "CMAKE_C_COMPILER": "${sourceDir}/scripts/hipcc-nv-wrapper.sh",
+                "CMAKE_CXX_COMPILER": "${sourceDir}/scripts/hipcc-nv-wrapper.sh",
+                "HIP_HIPCC_FLAGS": "-std=c++14"
+            }
+        },
+        {
+            "name": "use-hipcc",
+            "hidden": true,
+            "cacheVariables": {
+                "CMAKE_C_COMPILER": "hipcc",
+                "CMAKE_CXX_COMPILER": "hipcc",
+                "HIP_HIPCC_FLAGS": "-std=c++14"
+            }
+        },
+
+        {
+            "name": "rocm-hipcc",
+            "displayName": "Build for ROCm platform using hipcc without benchmark",
+            "inherits": [
+                "use-hipcc",
+                "use-platform-rocm",
+                "default-build-dir"
+            ]
+        },
+        {
+            "name": "cuda-hipcc",
+            "displayName": "Build for CUDA platform using hipcc without benchmark",
+            "inherits": [
+                "use-nv-hipcc-wrapper",
+                "use-platform-cuda",
+                "default-build-dir"
+            ]
+        },
+        {
+            "name": "rocm-hipcc-benchmark",
+            "displayName": "Build for ROCm platform using hipcc with benchmark enabled",
+            "inherits": [
+                "use-hipcc",
+                "enable-benchmark",
+                "use-platform-rocm",
+                "default-build-dir"
+            ]
+        },
+        {
+            "name": "cuda-hipcc-benchmark",
+            "displayName": "Build for CUDA platform using hipcc with benchmark enabled",
+            "inherits": [
+                "use-nv-hipcc-wrapper",
+                "enable-benchmark",
+                "use-platform-cuda",
+                "default-build-dir"
+            ]
+        }
+    ],
+    "buildPresets": [
+        {
+            "name": "rocm-hipcc",
+            "configurePreset": "rocm-hipcc"
+        },
+        {
+            "name": "cuda-hipcc",
+            "configurePreset": "cuda-hipcc"
+        },
+        {
+            "name": "rocm-hipcc-benchmark",
+            "configurePreset": "rocm-hipcc-benchmark"
+        },
+        {
+            "name": "cuda-hipcc-benchmark",
+            "configurePreset": "cuda-hipcc-benchmark"
+        }
+    ]
+}

--- a/README.md
+++ b/README.md
@@ -64,11 +64,10 @@ cmake --build ./build-hip-adaptive
 
 ### Build with benchmark
 ```bash
-# please remomber to change WARP_SIZE in hola-hip on rocm platform
-cmake -B ./build -S ./ \
-   -DBENCHMARK_FORCE_SYNC_KERNELS=ON -DSPMV_BUILD_BENCHMARK=ON -DSPMV_OMP_ENABLED_FLAG=ON \
-   -DCMAKE_CXX_FLAGS="-std=c++14" -DHIP_HIPCC_FLAGS="-std=c++14"
-cmake --build ./build -j 4
+# please remember to change WARP_SIZE in hola-hip on rocm platform
+cmake --list-presets 
+cmake --preset=rocm-hipcc-benchmark # or use --preset=cuda-hipcc-benchmark
+cmake --build --preset=rocm-hipcc-benchmark -j 4  # or use --preset=cuda-hipcc-benchmark
 ```
 
 ## For Developers

--- a/scripts/hipcc-nv-wrapper.sh
+++ b/scripts/hipcc-nv-wrapper.sh
@@ -1,27 +1,38 @@
-#!/bin/sh
+#!/bin/bash
 
-# this wrapper script is used for nvlink/hipcc to remove `-std=gnu++14` argument.
-
-LINKER=/opt/compilers/rocm/4.2.0/bin/hipcc
+LINKER="hipcc"
 newcmd="$LINKER"
-REMOVE="-std=gnu++14"
+flag_xcpp_appear=0
 
 for arg in $@
 do
   case $arg in
-    $REMOVE) # remove argument
+    "-hc") # 移除参数 `-hc`
       ;;
 
     # OpenMP
-    "-fopenmp")
+    "-fopenmp") # 添加参数 `-Xcompiler`
      newcmd="$newcmd -Xcompiler -fopenmp";;
 
-    "-fopenmp=libomp")
-      newcmd="$newcmd -Xcompiler -fopenmp";;
+    "-fpch-preprocess")
+     newcmd="$newcmd -Xcompiler -fpch-preprocess";;
+
+    "-xc++")
+     flag_xcpp_appear=1
+     newcmd="$newcmd -Xcompiler -xc++";;
+
+    "-fdiagnostics-color=always")
+    newcmd="$newcmd -Xcompiler -fdiagnostics-color=always";;
+
     *)
       newcmd="$newcmd $arg";;
   esac
 done
 
+
+#if [ "$flag_xcpp_appear" -eq 1 ]; then
+  echo "flag '-xc++' appears in this commane." >&2
+  echo $newcmd >&2
+#fi
 # Finally execute the new command
 exec $newcmd


### PR DESCRIPTION
Now, min cmake version is 3.21